### PR TITLE
Add default assignee and reviewer 'javiyt' for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,27 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+---
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "javiyt"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "javiyt"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    assignees:
-      - "javiyt"
-      
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt


### PR DESCRIPTION
This PR adds 'javiyt' as the default assignee and reviewer for all Dependabot updates.

This ensures that Dependabot pull requests are automatically assigned to @javiyt for review.

Automated change via a script.
